### PR TITLE
Add fallback font-family

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 * {
-	font-family: 'TT Norms';
+	font-family: 'TT Norms', sans-serif;
 }
 body {
 	background-color: #FDFBFD;


### PR DESCRIPTION
Hello! May I offer this PR to which fixes #3 for Hacktoberfest? 

When you want a sans-serif font stack, you can simply use `sans-serif` without including Helvetica, Arial, etc. The best available font will automatically be selected: Helvetica on Macs, and Arial on Windows PCs.
https://css-tricks.com/sans-serif/

Cheers!